### PR TITLE
Add nqp pragma

### DIFF
--- a/lib/Slang/Piersing.pm
+++ b/lib/Slang/Piersing.pm
@@ -1,3 +1,6 @@
+use v6;
+use nqp;
+
 sub EXPORT(|) {
     my role Piersing {
         token identifier {


### PR DESCRIPTION
... since code calling nqp routines directly needs to use this pragma.
`use v6` has also been added for good measure.

This makes the test suite pass again.  If you want me to take out the `use v6`, just let me know and I'll update the PR. It did seem like a good idea at the time.